### PR TITLE
removed guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,6 @@
 		<bouncycastle.version>1.54</bouncycastle.version>
 		<!-- so that build is not platform dependent via encoding -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<guava.version>19.0-rc2</guava.version>
 	</properties>
 
 	<dependencyManagement>
@@ -209,11 +208,6 @@
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
 				<version>${commons.lang.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava</artifactId>
-				<version>${guava.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>jdepend</groupId>

--- a/sejda-sambox/pom.xml
+++ b/sejda-sambox/pom.xml
@@ -70,10 +70,6 @@
 			<artifactId>commons-io</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
 			<version>${slf4j.version}</version>


### PR DESCRIPTION
If we use it only for hashing I'd prefer to remove it since it increases the sejda-console size of a 15-20%