### PR TITLE
close #416: Add information about the currently processed file 

### DIFF
--- a/sejda-core/src/main/java/org/sejda/core/service/DefaultTaskExecutionService.java
+++ b/sejda-core/src/main/java/org/sejda/core/service/DefaultTaskExecutionService.java
@@ -20,15 +20,6 @@
  */
 package org.sejda.core.service;
 
-import static java.util.Optional.ofNullable;
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
-import javax.validation.ConstraintViolation;
-
 import org.sejda.core.context.DefaultSejdaContext;
 import org.sejda.core.context.SejdaContext;
 import org.sejda.core.validation.DefaultValidationContext;
@@ -39,6 +30,14 @@ import org.sejda.model.task.NotifiableTaskMetadata;
 import org.sejda.model.task.TaskExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.validation.ConstraintViolation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Optional.ofNullable;
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
 
 /**
  * Default implementation of the {@link TaskExecutionService}.
@@ -130,7 +129,7 @@ public final class DefaultTaskExecutionService implements TaskExecutionService {
      * actual execution of the task
      *
      * @param parameters
-     * @param task
+     * @param executionContext
      * @throws TaskException
      */
     @SuppressWarnings("unchecked")

--- a/sejda-core/src/test/java/org/sejda/core/service/ExtractPagesTaskTest.java
+++ b/sejda-core/src/test/java/org/sejda/core/service/ExtractPagesTaskTest.java
@@ -19,24 +19,8 @@
  */
 package org.sejda.core.service;
 
-import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.sejda.TestUtils.encryptedAtRest;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-
 import org.junit.Ignore;
 import org.junit.Test;
-import org.sejda.core.TestListenerFactory;
-import org.sejda.core.TestListenerFactory.TestListenerFailed;
-import org.sejda.core.notification.context.ThreadLocalNotificationContext;
 import org.sejda.model.exception.TaskNonLenientExecutionException;
 import org.sejda.model.optimization.OptimizationPolicy;
 import org.sejda.model.output.ExistingOutputPolicy;
@@ -48,6 +32,19 @@ import org.sejda.sambox.cos.COSDictionary;
 import org.sejda.sambox.cos.COSName;
 import org.sejda.sambox.pdmodel.PDDocument;
 import org.sejda.sambox.pdmodel.PDPage;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.sejda.TestUtils.encryptedAtRest;
 
 /**
  * Test for an extract pages task.
@@ -132,10 +129,8 @@ public abstract class ExtractPagesTaskTest extends BaseTaskTest<ExtractPagesPara
     public void extractWrongPageRages() throws IOException {
         setUpParametersWrongPageRanges();
         testContext.directoryOutputTo(parameters);
-        TestListenerFailed failListener = TestListenerFactory.newFailedListener();
-        ThreadLocalNotificationContext.getContext().addListener(failListener);
         execute(parameters);
-        assertTrue(failListener.isFailed());
+        testContext.assertTaskFailed();
     }
 
     @Test

--- a/sejda-core/src/test/java/org/sejda/core/service/TaskTestContext.java
+++ b/sejda-core/src/test/java/org/sejda/core/service/TaskTestContext.java
@@ -18,33 +18,6 @@
  */
 package org.sejda.core.service;
 
-import static java.util.Objects.nonNull;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.*;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
 import org.sejda.commons.util.IOUtils;
 import org.sejda.core.Sejda;
@@ -68,11 +41,40 @@ import org.sejda.sambox.pdmodel.interactive.documentnavigation.outline.PDDocumen
 import org.sejda.sambox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
 import org.sejda.sambox.pdmodel.interactive.documentnavigation.outline.PDOutlineNode;
 
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 /**
  * Context to be used in tests
- * 
- * @author Andrea Vacondio
  *
+ * @author Andrea Vacondio
  */
 public class TaskTestContext implements Closeable {
 
@@ -82,7 +84,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * Initialize the given params with a {@link FileTaskOutput}
-     * 
+     *
      * @param params
      * @return
      */
@@ -95,7 +97,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * Initialize the given params with a {@link FileTaskOutput} on a file with the given extension
-     * 
+     *
      * @param params
      * @param extension
      * @return
@@ -110,7 +112,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * Initialize the given params with a {@link DirectoryTaskOutput}
-     * 
+     *
      * @param params
      * @return
      * @throws IOException
@@ -124,7 +126,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * Initialize the given params with a directory as {@link FileOrDirectoryTaskOutput}
-     * 
+     *
      * @param params
      * @return
      */
@@ -137,7 +139,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * Initialize the given params with a pdf file as {@link FileOrDirectoryTaskOutput}
-     * 
+     *
      * @param params
      * @return
      */
@@ -150,7 +152,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * asserts the creator has been set to the info dictionary
-     * 
+     *
      * @return
      */
     public TaskTestContext assertCreator() {
@@ -161,7 +163,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * asserts the PDF version of the output is the given one
-     * 
+     *
      * @return
      */
     public TaskTestContext assertVersion(PdfVersion version) {
@@ -172,7 +174,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * asserts the output document has that number of pages
-     * 
+     *
      * @return
      */
     public TaskTestContext assertPages(int expected) {
@@ -183,7 +185,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * asserts the output document with the given filename exists and has that number of pages. This assert will work only for multiple output task.
-     * 
+     *
      * @return
      * @throws IOException
      * @see this{@link #assertPages(int)}
@@ -211,7 +213,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * assert that the document has an acroform with some field in it
-     * 
+     *
      * @param hasForms
      */
     public TaskTestContext assertHasAcroforms(boolean hasForms) {
@@ -227,8 +229,8 @@ public class TaskTestContext implements Closeable {
 
     /**
      * assert the document outline contains an item with the given title
-     * 
-     * @param string
+     *
+     * @param title
      * @return
      */
     public TaskTestContext assertOutlineContains(String title) {
@@ -243,8 +245,8 @@ public class TaskTestContext implements Closeable {
 
     /**
      * assert the document outline doesn't contain an item with the given title
-     * 
-     * @param string
+     *
+     * @param title
      * @return
      */
     public TaskTestContext assertOutlineDoesntContain(String title) {
@@ -277,7 +279,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * asserts that a multiple output task has generated the given number of output files, hidden files don't count
-     * 
+     *
      * @return
      * @throws IOException
      */
@@ -306,7 +308,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * asserts that a multiple output task has generated the given number of output files, including hidden files (in case the task is expected to have some hidden leftover)
-     * 
+     *
      * @param size
      * @return
      */
@@ -324,7 +326,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * asserts that a multiple output task has generated no output
-     * 
+     *
      * @return
      */
     public TaskTestContext assertEmptyMultipleOutput() {
@@ -337,7 +339,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * asserts that a multiple output task has generated the given file names
-     * 
+     *
      * @param filenames
      * @return
      */
@@ -352,7 +354,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * Applies the given consumer to every generated output
-     * 
+     *
      * @param consumer
      * @return
      * @throws IOException
@@ -376,7 +378,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * Applies the given consumer to generated single output PDF document
-     * 
+     *
      * @param consumer
      * @return
      * @throws IOException
@@ -389,7 +391,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * Applies the given consumer to generated output PDF document with the given name
-     * 
+     *
      * @param consumer
      * @return
      * @throws IOException
@@ -406,7 +408,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * Applies the given consumer to every generated output
-     * 
+     *
      * @param consumer
      * @return
      * @throws IOException
@@ -419,7 +421,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * Applies the given consumer to a single generated output
-     * 
+     *
      * @param consumer
      * @return
      * @throws IOException
@@ -452,7 +454,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * Asserts that the task has completed and generated some output. If a single output task, then the output is paresed and a {@link PDDocument} is returned
-     * 
+     *
      * @return
      * @throws IOException
      */
@@ -462,7 +464,7 @@ public class TaskTestContext implements Closeable {
 
     /**
      * Asserts that the task has completed and generated some output. If the task generated a single output, then the output is parsed and a {@link PDDocument} is returned
-     * 
+     *
      * @param password
      * @return
      * @throws IOException
@@ -491,6 +493,7 @@ public class TaskTestContext implements Closeable {
     }
 
     Throwable taskFailureCause = null;
+    String failedSource;
     List<String> taskWarnings = new ArrayList<>();
 
     private EventListener<TaskExecutionWarningEvent> warningsListener = new EventListener<TaskExecutionWarningEvent>() {
@@ -504,6 +507,7 @@ public class TaskTestContext implements Closeable {
         @Override
         public void onEvent(TaskExecutionFailedEvent event) {
             taskFailureCause = event.getFailingCause();
+            failedSource = event.getNotifiableTaskMetadata().getCurrentSource();
         }
     };
 
@@ -522,6 +526,16 @@ public class TaskTestContext implements Closeable {
     public TaskTestContext assertTaskFailed(Class<? extends Throwable> cause) {
         assertNotNull(taskFailureCause);
         assertThat(taskFailureCause, instanceOf(cause));
+        return this;
+    }
+
+    public TaskTestContext assertTaskFailed() {
+        assertNotNull(taskFailureCause);
+        return this;
+    }
+
+    public TaskTestContext assertFailedSource(String source) {
+        assertEquals(source, failedSource);
         return this;
     }
 

--- a/sejda-model/src/main/java/org/sejda/model/task/NotifiableTaskMetadata.java
+++ b/sejda-model/src/main/java/org/sejda/model/task/NotifiableTaskMetadata.java
@@ -1,7 +1,7 @@
 /*
  * Created on 28/ott/2011
  * Copyright 2011 by Andrea Vacondio (andrea.vacondio@gmail.com).
- * 
+ *
  * This file is part of the Sejda source code
  *
  * This program is free software: you can redistribute it and/or modify
@@ -19,8 +19,12 @@
  */
 package org.sejda.model.task;
 
-import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.sejda.model.input.TaskSource;
 
 import java.io.File;
 import java.io.Serializable;
@@ -29,17 +33,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import static java.util.Objects.nonNull;
+import static org.sejda.commons.util.RequireUtils.requireNotNullArg;
 
 /**
  * An set of metadata related to the task the event is notifying about.
- * 
+ *
  * @author Andrea Vacondio
- * 
  */
 public class NotifiableTaskMetadata implements Serializable {
 
@@ -51,15 +51,14 @@ public class NotifiableTaskMetadata implements Serializable {
     private UUID taskIdentifier;
     private String qualifiedName;
     private List<File> taskOutput = new ArrayList<>();
+    private String currentSource;
 
     private NotifiableTaskMetadata() {
         // empty constructor
     }
 
     public NotifiableTaskMetadata(Task<?> task) {
-        if (isNull(task)) {
-            throw new IllegalArgumentException("No task given, unable to create notifiable metadata.");
-        }
+        requireNotNullArg(task, "No task given, unable to create notifiable metadata.");
         this.taskIdentifier = UUID.randomUUID();
         this.qualifiedName = task.getClass().getName();
     }
@@ -82,6 +81,18 @@ public class NotifiableTaskMetadata implements Serializable {
         if (nonNull(output)) {
             taskOutput.add(output);
         }
+    }
+
+    public void setCurrentSource(TaskSource<?> source) {
+        this.currentSource = source.getName();
+    }
+
+    public void clearCurrentSource() {
+        this.currentSource = "";
+    }
+
+    public String getCurrentSource() {
+        return this.currentSource;
     }
 
     /**
@@ -117,9 +128,8 @@ public class NotifiableTaskMetadata implements Serializable {
 
     /**
      * Null object pattern providing empty behavior.
-     * 
+     *
      * @author Andrea Vacondio
-     * 
      */
     private static class NullNotifiableTaskMetadata extends NotifiableTaskMetadata {
 

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/ExtractByOutlineTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/ExtractByOutlineTask.java
@@ -16,8 +16,6 @@
  */
 package org.sejda.impl.sambox;
 
-import static org.sejda.commons.util.IOUtils.closeQuietly;
-
 import org.sejda.impl.sambox.component.DefaultPdfSourceOpener;
 import org.sejda.impl.sambox.component.PDDocumentHandler;
 import org.sejda.impl.sambox.component.SamboxOutlineLevelsHandler;
@@ -32,6 +30,8 @@ import org.sejda.model.task.TaskExecutionContext;
 import org.sejda.sambox.pdmodel.PDDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.sejda.commons.util.IOUtils.closeQuietly;
 
 /**
  * Extract chapters to separate documents based on the bookmarks in the outline
@@ -54,6 +54,7 @@ public class ExtractByOutlineTask extends BaseTask<ExtractByOutlineParameters> {
     public void execute(ExtractByOutlineParameters parameters) throws TaskException {
         for(PdfSource<?> source: parameters.getSourceList()) {
             LOG.debug("Opening {} ", source);
+            executionContext().notifiableTaskMetadata().setCurrentSource(source);
             document = source.open(documentLoader).getUnderlyingPDDocument();
 
             LOG.debug("Retrieving outline information for level {} and match regex {}", parameters.getLevel(),
@@ -68,7 +69,7 @@ public class ExtractByOutlineTask extends BaseTask<ExtractByOutlineParameters> {
 
             closeQuietly(document);
         }
-
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
         LOG.debug("Extraction completed and outputs written to {}", parameters.getOutput());
     }
 

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/ExtractPagesTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/ExtractPagesTask.java
@@ -18,17 +18,6 @@
  */
 package org.sejda.impl.sambox;
 
-import static java.util.Optional.ofNullable;
-import static org.sejda.commons.util.IOUtils.closeQuietly;
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
-import static org.sejda.core.support.io.model.FileOutput.file;
-import static org.sejda.core.support.prefix.NameGenerator.nameGenerator;
-import static org.sejda.core.support.prefix.model.NameGenerationRequest.nameRequest;
-
-import java.io.File;
-import java.util.Set;
-
 import org.sejda.core.support.io.MultipleOutputWriter;
 import org.sejda.core.support.io.OutputWriters;
 import org.sejda.impl.sambox.component.DefaultPdfSourceOpener;
@@ -44,6 +33,17 @@ import org.sejda.model.task.BaseTask;
 import org.sejda.model.task.TaskExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Set;
+
+import static java.util.Optional.ofNullable;
+import static org.sejda.commons.util.IOUtils.closeQuietly;
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
+import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
+import static org.sejda.core.support.io.model.FileOutput.file;
+import static org.sejda.core.support.prefix.NameGenerator.nameGenerator;
+import static org.sejda.core.support.prefix.model.NameGenerationRequest.nameRequest;
 
 /**
  * SAMBox implementation of the task responsible for extracting pages from a given pdf document.
@@ -74,6 +74,7 @@ public class ExtractPagesTask extends BaseTask<ExtractPagesParameters> {
         for (PdfSource<?> source : parameters.getSourceList()) {
 
             LOG.debug("Opening {}", source);
+            executionContext().notifiableTaskMetadata().setCurrentSource(source);
             sourceDocumentHandler = source.open(documentLoader);
             sourceDocumentHandler.getPermissions().ensurePermission(PdfAccessPermission.ASSEMBLE);
 
@@ -125,7 +126,7 @@ public class ExtractPagesTask extends BaseTask<ExtractPagesParameters> {
             closeQuietly(sourceDocumentHandler);
             notifyEvent(executionContext().notifiableTaskMetadata()).stepsCompleted(++currentStep).outOf(totalSteps);
         }
-
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
         parameters.getOutput().accept(outputWriter);
         LOG.debug("Pages extracted and written to {}", parameters.getOutput());
     }

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/MergeTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/MergeTask.java
@@ -18,19 +18,6 @@
  */
 package org.sejda.impl.sambox;
 
-import static java.util.Optional.ofNullable;
-import static org.sejda.commons.util.IOUtils.closeQuietly;
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-import static org.sejda.impl.sambox.component.SignatureClipper.clipSignatures;
-
-import java.io.Closeable;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Queue;
-import java.util.Set;
-
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.sejda.commons.LookupTable;
@@ -63,6 +50,19 @@ import org.sejda.sambox.pdmodel.common.PDRectangle;
 import org.sejda.sambox.pdmodel.interactive.annotation.PDAnnotation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+
+import static java.util.Optional.ofNullable;
+import static org.sejda.commons.util.IOUtils.closeQuietly;
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
+import static org.sejda.impl.sambox.component.SignatureClipper.clipSignatures;
 
 /**
  * SAMBox implementation of the Merge task that merges together a number of documents or part of them.
@@ -123,6 +123,7 @@ public class MergeTask extends BaseTask<MergeParameters> {
         for (PdfMergeInput input : parameters.getPdfInputList()) {
             inputsCounter++;
             LOG.debug("Opening {}", input.getSource());
+            executionContext().notifiableTaskMetadata().setCurrentSource(input.getSource());
             PDDocumentHandler sourceDocumentHandler = input.getSource().open(sourceOpener);
             toClose.add(sourceDocumentHandler);
 
@@ -209,6 +210,8 @@ public class MergeTask extends BaseTask<MergeParameters> {
 
             notifyEvent(executionContext().notifiableTaskMetadata()).stepsCompleted(++currentStep).outOf(totalSteps);
         }
+
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
 
         if (outlineMerger.hasOutline()) {
             LOG.debug("Adding generated outline");

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/PdfToMultipleImageTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/PdfToMultipleImageTask.java
@@ -18,19 +18,6 @@
  */
 package org.sejda.impl.sambox;
 
-import static java.util.Optional.ofNullable;
-import static org.sejda.commons.util.IOUtils.closeQuietly;
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
-import static org.sejda.core.support.io.OutputWriters.newMultipleOutputWriter;
-import static org.sejda.core.support.io.model.FileOutput.file;
-import static org.sejda.core.support.prefix.NameGenerator.nameGenerator;
-import static org.sejda.core.support.prefix.model.NameGenerationRequest.nameRequest;
-
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.util.Set;
-
 import org.sejda.core.Sejda;
 import org.sejda.core.support.io.MultipleOutputWriter;
 import org.sejda.core.support.util.RuntimeUtils;
@@ -43,6 +30,19 @@ import org.sejda.model.parameter.image.AbstractPdfToMultipleImageParameters;
 import org.sejda.model.task.TaskExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.Set;
+
+import static java.util.Optional.ofNullable;
+import static org.sejda.commons.util.IOUtils.closeQuietly;
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
+import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
+import static org.sejda.core.support.io.OutputWriters.newMultipleOutputWriter;
+import static org.sejda.core.support.io.model.FileOutput.file;
+import static org.sejda.core.support.prefix.NameGenerator.nameGenerator;
+import static org.sejda.core.support.prefix.model.NameGenerationRequest.nameRequest;
 
 /**
  * SAMBox implementation of a task which converts a pdf document to a collection of images, one image per page.
@@ -75,6 +75,7 @@ public class PdfToMultipleImageTask<T extends AbstractPdfToMultipleImageParamete
             currentStep++;
             try {
                 LOG.debug("Opening {}", source);
+                executionContext().notifiableTaskMetadata().setCurrentSource(source);
                 documentHandler = source.open(sourceOpener);
 
                 Set<Integer> requestedPages = parameters.getPages(documentHandler.getNumberOfPages());
@@ -129,6 +130,7 @@ public class PdfToMultipleImageTask<T extends AbstractPdfToMultipleImageParamete
             }
             notifyEvent(executionContext().notifiableTaskMetadata()).stepsCompleted(currentStep).outOf(totalSteps);
         }
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
 
         parameters.getOutput().accept(outputWriter);
         LOG.debug("Documents converted to {} and saved to {}", parameters.getOutputImageType(), parameters.getOutput());

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/PdfToSingleImageTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/PdfToSingleImageTask.java
@@ -18,14 +18,6 @@
  */
 package org.sejda.impl.sambox;
 
-import static org.sejda.commons.util.IOUtils.closeQuietly;
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
-import static org.sejda.core.support.io.OutputWriters.newSingleOutputWriter;
-
-import java.awt.image.BufferedImage;
-import java.io.File;
-
 import org.sejda.core.support.io.SingleOutputWriter;
 import org.sejda.impl.sambox.component.DefaultPdfSourceOpener;
 import org.sejda.impl.sambox.component.PDDocumentHandler;
@@ -36,6 +28,14 @@ import org.sejda.model.parameter.image.AbstractPdfToSingleImageParameters;
 import org.sejda.model.task.TaskExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+
+import static org.sejda.commons.util.IOUtils.closeQuietly;
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
+import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
+import static org.sejda.core.support.io.OutputWriters.newSingleOutputWriter;
 
 /**
  * SAMBox implementation of a task which converts a pdf document to an image format that supports multiple images into a single image.
@@ -70,6 +70,7 @@ public class PdfToSingleImageTask<T extends AbstractPdfToSingleImageParameters> 
         LOG.debug("Temporary output set to {}", tmpFile);
 
         LOG.debug("Opening {}", parameters.getSource());
+        executionContext().notifiableTaskMetadata().setCurrentSource(parameters.getSource());
         documentHandler = parameters.getSource().open(sourceOpener);
 
         int numberOfPages = documentHandler.getNumberOfPages();
@@ -91,6 +92,7 @@ public class PdfToSingleImageTask<T extends AbstractPdfToSingleImageParameters> 
             notifyEvent(executionContext().notifiableTaskMetadata()).stepsCompleted(page + 1).outOf(numberOfPages);
         }
         getWriter().closeDestination();
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
 
         parameters.getOutput().accept(outputWriter);
         LOG.debug("Document converted to {} and saved to {}", parameters.getOutputImageType(), parameters.getOutput());

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/RotateTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/RotateTask.java
@@ -18,16 +18,6 @@
  */
 package org.sejda.impl.sambox;
 
-import static java.util.Optional.ofNullable;
-import static org.sejda.commons.util.IOUtils.closeQuietly;
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
-import static org.sejda.core.support.io.model.FileOutput.file;
-import static org.sejda.core.support.prefix.NameGenerator.nameGenerator;
-import static org.sejda.core.support.prefix.model.NameGenerationRequest.nameRequest;
-
-import java.io.File;
-
 import org.sejda.core.support.io.MultipleOutputWriter;
 import org.sejda.core.support.io.OutputWriters;
 import org.sejda.impl.sambox.component.DefaultPdfSourceOpener;
@@ -44,6 +34,16 @@ import org.sejda.model.task.TaskExecutionContext;
 import org.sejda.sambox.pdmodel.PageNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import static java.util.Optional.ofNullable;
+import static org.sejda.commons.util.IOUtils.closeQuietly;
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
+import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
+import static org.sejda.core.support.io.model.FileOutput.file;
+import static org.sejda.core.support.prefix.NameGenerator.nameGenerator;
+import static org.sejda.core.support.prefix.model.NameGenerationRequest.nameRequest;
 
 /**
  * SAMBox implementation of a task performing pages rotation on a list of {@link PdfSource}.
@@ -76,6 +76,7 @@ public class RotateTask extends BaseTask<RotateParameters> {
 
             int fileNumber = executionContext().incrementAndGetOutputDocumentsCounter();
             LOG.debug("Opening {}", source);
+            executionContext().notifiableTaskMetadata().setCurrentSource(source);
             try {
                 documentHandler = source.open(documentLoader);
                 documentHandler.getPermissions().ensurePermission(PdfAccessPermission.ASSEMBLE);
@@ -116,6 +117,7 @@ public class RotateTask extends BaseTask<RotateParameters> {
 
             notifyEvent(executionContext().notifiableTaskMetadata()).stepsCompleted(fileNumber).outOf(totalSteps);
         }
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
 
         parameters.getOutput().accept(outputWriter);
         LOG.debug("Input documents rotated and written to {}", parameters.getOutput());

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/SetMetadataTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/SetMetadataTask.java
@@ -41,10 +41,18 @@ import org.xml.sax.SAXParseException;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.*;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.URIResolver;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import javax.xml.xpath.*;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathFactoryConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -95,6 +103,7 @@ public class SetMetadataTask extends BaseTask<SetMetadataParameters> {
             
             try {
                 LOG.debug("Opening {}", source);
+                executionContext().notifiableTaskMetadata().setCurrentSource(source);
 
                 documentHandler = source.open(documentLoader);
                 documentHandler.setUpdateProducerModifiedDate(parameters.isUpdateProducerModifiedDate());
@@ -156,6 +165,7 @@ public class SetMetadataTask extends BaseTask<SetMetadataParameters> {
             notifyEvent(executionContext().notifiableTaskMetadata()).stepsCompleted(fileNumber).outOf(totalSteps);
         }
 
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
         parameters.getOutput().accept(outputWriter);
         LOG.debug("Metadata set and written to {}", parameters.getOutput());
 

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/SetPagesLabelTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/SetPagesLabelTask.java
@@ -18,12 +18,6 @@
  */
 package org.sejda.impl.sambox;
 
-import static org.sejda.commons.util.IOUtils.closeQuietly;
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
-
-import java.io.File;
-
 import org.sejda.core.support.io.OutputWriters;
 import org.sejda.core.support.io.SingleOutputWriter;
 import org.sejda.impl.sambox.component.DefaultPdfSourceOpener;
@@ -36,6 +30,12 @@ import org.sejda.model.task.BaseTask;
 import org.sejda.model.task.TaskExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import static org.sejda.commons.util.IOUtils.closeQuietly;
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
+import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
 
 /**
  * SAMBox implementation of a task that applies page labels to a given document
@@ -64,6 +64,8 @@ public class SetPagesLabelTask extends BaseTask<SetPagesLabelParameters> {
 
         PdfSource<?> source = parameters.getSource();
         LOG.debug("Opening {}", source);
+        executionContext().notifiableTaskMetadata().setCurrentSource(source);
+
         documentHandler = source.open(documentLoader);
 
         File tmpFile = createTemporaryBuffer(parameters.getOutput());
@@ -79,6 +81,7 @@ public class SetPagesLabelTask extends BaseTask<SetPagesLabelParameters> {
         documentHandler.savePDDocument(tmpFile, parameters.getOutput().getEncryptionAtRestPolicy());
         closeQuietly(documentHandler);
 
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
         parameters.getOutput().accept(outputWriter);
         LOG.debug("Labels applied to {}", parameters.getOutput());
     }

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/SetPagesTransitionTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/SetPagesTransitionTask.java
@@ -18,17 +18,6 @@
  */
 package org.sejda.impl.sambox;
 
-import static java.util.Optional.ofNullable;
-import static org.sejda.commons.util.IOUtils.closeQuietly;
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
-import static org.sejda.impl.sambox.util.TransitionUtils.getTransition;
-import static org.sejda.impl.sambox.util.TransitionUtils.initTransitionDimension;
-import static org.sejda.impl.sambox.util.TransitionUtils.initTransitionDirection;
-import static org.sejda.impl.sambox.util.TransitionUtils.initTransitionMotion;
-
-import java.io.File;
-
 import org.sejda.core.support.io.OutputWriters;
 import org.sejda.core.support.io.SingleOutputWriter;
 import org.sejda.impl.sambox.component.DefaultPdfSourceOpener;
@@ -45,6 +34,17 @@ import org.sejda.sambox.pdmodel.interactive.pagenavigation.PDTransition;
 import org.sejda.sambox.pdmodel.interactive.pagenavigation.PDTransitionStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import static java.util.Optional.ofNullable;
+import static org.sejda.commons.util.IOUtils.closeQuietly;
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
+import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
+import static org.sejda.impl.sambox.util.TransitionUtils.getTransition;
+import static org.sejda.impl.sambox.util.TransitionUtils.initTransitionDimension;
+import static org.sejda.impl.sambox.util.TransitionUtils.initTransitionDirection;
+import static org.sejda.impl.sambox.util.TransitionUtils.initTransitionMotion;
 
 /**
  * SAMBox implementation of a task that applies pages transitions to an input document.
@@ -74,6 +74,7 @@ public class SetPagesTransitionTask extends BaseTask<SetPagesTransitionParameter
 
         PdfSource<?> source = parameters.getSource();
         LOG.debug("Opening {}", source);
+        executionContext().notifiableTaskMetadata().setCurrentSource(source);
         documentHandler = source.open(documentLoader);
 
         File tmpFile = createTemporaryBuffer(parameters.getOutput());
@@ -106,6 +107,7 @@ public class SetPagesTransitionTask extends BaseTask<SetPagesTransitionParameter
         documentHandler.savePDDocument(tmpFile, parameters.getOutput().getEncryptionAtRestPolicy());
         closeQuietly(documentHandler);
 
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
         parameters.getOutput().accept(outputWriter);
         LOG.debug("Transitions set on {}", parameters.getOutput());
     }

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/SplitByOutlineLevelTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/SplitByOutlineLevelTask.java
@@ -18,9 +18,6 @@
  */
 package org.sejda.impl.sambox;
 
-import static org.sejda.commons.util.IOUtils.closeQuietly;
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-
 import org.sejda.impl.sambox.component.DefaultPdfSourceOpener;
 import org.sejda.impl.sambox.component.PDDocumentHandler;
 import org.sejda.impl.sambox.component.SamboxOutlineLevelsHandler;
@@ -36,6 +33,9 @@ import org.sejda.model.task.TaskExecutionContext;
 import org.sejda.sambox.pdmodel.PDDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.sejda.commons.util.IOUtils.closeQuietly;
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
 
 /**
  * Task splitting an input pdf document on a set of pages given by an outline level defined in the input parameter.
@@ -67,6 +67,7 @@ public class SplitByOutlineLevelTask extends BaseTask<SplitByOutlineLevelParamet
         for (PdfSource<?> source : parameters.getSourceList()) {
             currentStep++;
             LOG.debug("Opening {} ", source);
+            executionContext().notifiableTaskMetadata().setCurrentSource(source);
             document = source.open(documentLoader).getUnderlyingPDDocument();
 
             LOG.debug("Retrieving outline information for level {}", parameters.getLevelToSplitAt());
@@ -80,6 +81,7 @@ public class SplitByOutlineLevelTask extends BaseTask<SplitByOutlineLevelParamet
 
             notifyEvent(executionContext().notifiableTaskMetadata()).stepsCompleted(currentStep).outOf(totalSteps);
         }
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
         LOG.debug("Input documents splitted and written to {}", parameters.getOutput());
     }
 

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/SplitByPageNumbersTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/SplitByPageNumbersTask.java
@@ -18,9 +18,6 @@
  */
 package org.sejda.impl.sambox;
 
-import static org.sejda.commons.util.IOUtils.closeQuietly;
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-
 import org.sejda.impl.sambox.component.DefaultPdfSourceOpener;
 import org.sejda.impl.sambox.component.PDDocumentHandler;
 import org.sejda.impl.sambox.component.optimization.OptimizationRuler;
@@ -34,6 +31,9 @@ import org.sejda.model.task.TaskExecutionContext;
 import org.sejda.sambox.pdmodel.PDDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.sejda.commons.util.IOUtils.closeQuietly;
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
 
 /**
  * Task splitting an input pdf document on a set of pages defined in the input parameter object.
@@ -66,6 +66,7 @@ public class SplitByPageNumbersTask<T extends AbstractSplitByPageParameters> ext
             currentStep++;
 
             LOG.debug("Opening {}", source);
+            executionContext().notifiableTaskMetadata().setCurrentSource(source);
             document = source.open(documentLoader).getUnderlyingPDDocument();
 
             splitter = new PagesPdfSplitter<>(document, parameters,
@@ -79,6 +80,7 @@ public class SplitByPageNumbersTask<T extends AbstractSplitByPageParameters> ext
             notifyEvent(executionContext().notifiableTaskMetadata()).stepsCompleted(currentStep).outOf(totalSteps);
         }
 
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
         LOG.debug("Input documents split and written to {}", parameters.getOutput());
     }
 

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/UnpackTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/UnpackTask.java
@@ -18,20 +18,6 @@
  */
 package org.sejda.impl.sambox;
 
-import static java.util.Objects.nonNull;
-import static java.util.Optional.ofNullable;
-import static org.sejda.commons.util.IOUtils.closeQuietly;
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
-import static org.sejda.core.support.io.model.FileOutput.file;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Stream;
-
 import org.apache.commons.io.FileUtils;
 import org.sejda.core.support.io.MultipleOutputWriter;
 import org.sejda.core.support.io.OutputWriters;
@@ -50,6 +36,20 @@ import org.sejda.sambox.pdmodel.common.filespecification.PDComplexFileSpecificat
 import org.sejda.sambox.pdmodel.interactive.annotation.PDAnnotationFileAttachment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.util.Objects.nonNull;
+import static java.util.Optional.ofNullable;
+import static org.sejda.commons.util.IOUtils.closeQuietly;
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
+import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
+import static org.sejda.core.support.io.model.FileOutput.file;
 
 /**
  * SAMBox implementation of a task that unpacks files attached to a collection of input documents.
@@ -81,6 +81,7 @@ public class UnpackTask extends BaseTask<UnpackParameters> {
             currentStep++;
             try {
                 LOG.debug("Opening {}", source);
+                executionContext().notifiableTaskMetadata().setCurrentSource(source);
                 sourceDocumentHandler = source.open(documentLoader);
 
                 Map<String, PDComplexFileSpecification> names = new HashMap<>();
@@ -101,6 +102,7 @@ public class UnpackTask extends BaseTask<UnpackParameters> {
             notifyEvent(executionContext().notifiableTaskMetadata()).stepsCompleted(currentStep).outOf(totalSteps);
         }
 
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
         parameters.getOutput().accept(outputWriter);
         LOG.debug("Attachments unpacked and written to {}", parameters.getOutput());
     }

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/ViewerPreferencesTask.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/ViewerPreferencesTask.java
@@ -18,21 +18,6 @@
  */
 package org.sejda.impl.sambox;
 
-import static java.util.Optional.ofNullable;
-import static org.sejda.commons.util.IOUtils.closeQuietly;
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
-import static org.sejda.core.support.io.model.FileOutput.file;
-import static org.sejda.core.support.prefix.NameGenerator.nameGenerator;
-import static org.sejda.core.support.prefix.model.NameGenerationRequest.nameRequest;
-import static org.sejda.impl.sambox.util.ViewerPreferencesUtils.getDirection;
-import static org.sejda.impl.sambox.util.ViewerPreferencesUtils.getDuplex;
-import static org.sejda.impl.sambox.util.ViewerPreferencesUtils.getNFSMode;
-import static org.sejda.impl.sambox.util.ViewerPreferencesUtils.getPrintScaling;
-import static org.sejda.impl.sambox.util.ViewerPreferencesUtils.setBooleanPreferences;
-
-import java.io.File;
-
 import org.sejda.core.support.io.MultipleOutputWriter;
 import org.sejda.core.support.io.OutputWriters;
 import org.sejda.impl.sambox.component.DefaultPdfSourceOpener;
@@ -50,6 +35,21 @@ import org.sejda.sambox.pdmodel.interactive.viewerpreferences.PDViewerPreference
 import org.sejda.sambox.pdmodel.interactive.viewerpreferences.PDViewerPreferences.READING_DIRECTION;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import static java.util.Optional.ofNullable;
+import static org.sejda.commons.util.IOUtils.closeQuietly;
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
+import static org.sejda.core.support.io.IOUtils.createTemporaryBuffer;
+import static org.sejda.core.support.io.model.FileOutput.file;
+import static org.sejda.core.support.prefix.NameGenerator.nameGenerator;
+import static org.sejda.core.support.prefix.model.NameGenerationRequest.nameRequest;
+import static org.sejda.impl.sambox.util.ViewerPreferencesUtils.getDirection;
+import static org.sejda.impl.sambox.util.ViewerPreferencesUtils.getDuplex;
+import static org.sejda.impl.sambox.util.ViewerPreferencesUtils.getNFSMode;
+import static org.sejda.impl.sambox.util.ViewerPreferencesUtils.getPrintScaling;
+import static org.sejda.impl.sambox.util.ViewerPreferencesUtils.setBooleanPreferences;
 
 /**
  * SAMBox implementation of a task setting viewer preferences on a list of {@link PdfSource}.
@@ -80,6 +80,7 @@ public class ViewerPreferencesTask extends BaseTask<ViewerPreferencesParameters>
         for (PdfSource<?> source : parameters.getSourceList()) {
             int fileNumber = executionContext().incrementAndGetOutputDocumentsCounter();
             LOG.debug("Opening {}", source);
+            executionContext().notifiableTaskMetadata().setCurrentSource(source);
             documentHandler = source.open(documentLoader);
             documentHandler.setCreatorOnPDDocument();
 
@@ -105,6 +106,7 @@ public class ViewerPreferencesTask extends BaseTask<ViewerPreferencesParameters>
             notifyEvent(executionContext().notifiableTaskMetadata()).stepsCompleted(fileNumber).outOf(totalSteps);
         }
 
+        executionContext().notifiableTaskMetadata().clearCurrentSource();
         parameters.getOutput().accept(outputWriter);
         LOG.debug("Viewer preferences set on input documents and written to {}", parameters.getOutput());
 

--- a/sejda-sambox/src/main/java/org/sejda/impl/sambox/component/image/ImagesToPdfDocumentConverter.java
+++ b/sejda-sambox/src/main/java/org/sejda/impl/sambox/component/image/ImagesToPdfDocumentConverter.java
@@ -18,14 +18,6 @@
  */
 package org.sejda.impl.sambox.component.image;
 
-import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
-import static org.sejda.core.support.io.IOUtils.createTemporaryBufferWithName;
-
-import java.awt.Point;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.commons.io.FilenameUtils;
 import org.sejda.impl.sambox.component.PDDocumentHandler;
 import org.sejda.impl.sambox.component.PageImageWriter;
@@ -46,6 +38,14 @@ import org.sejda.sambox.pdmodel.common.PDRectangle;
 import org.sejda.sambox.pdmodel.graphics.image.PDImageXObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.awt.Point;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.sejda.core.notification.dsl.ApplicationEventsNotifier.notifyEvent;
+import static org.sejda.core.support.io.IOUtils.createTemporaryBufferWithName;
 
 public class ImagesToPdfDocumentConverter {
 
@@ -148,8 +148,11 @@ public class ImagesToPdfDocumentConverter {
         List<MergeInput> newInputList = new ArrayList<>();
         for (MergeInput input : parameters.getInputList()) {
             if (input instanceof ImageMergeInput) {
+                ImageMergeInput image = (ImageMergeInput) input;
                 // collect all consecutive images and convert them to a PDF document
-                newInputList.add(convertImagesToPdfMergeInput((ImageMergeInput) input, context));
+                context.notifiableTaskMetadata().setCurrentSource(image.getSource());
+                newInputList.add(convertImagesToPdfMergeInput(image, context));
+                context.notifiableTaskMetadata().clearCurrentSource();
             } else {
                 newInputList.add(input);
             }
@@ -180,7 +183,7 @@ public class ImagesToPdfDocumentConverter {
         if (image.isShouldPageSizeMatchImageSize()) {
             pageSize = null;
         }
-        
+
         PDDocumentHandler converted = converter.addPage(image.getSource(), pageSize, image.getPageOrientation(), 0);
         String basename = FilenameUtils.getBaseName(image.getSource().getName());
         String filename = String.format("%s.pdf", basename);

--- a/sejda-sambox/src/test/java/org/sejda/impl/sambox/MergeSamboxTaskTest.java
+++ b/sejda-sambox/src/test/java/org/sejda/impl/sambox/MergeSamboxTaskTest.java
@@ -18,30 +18,8 @@
  */
 package org.sejda.impl.sambox;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.*;
-import static org.sejda.TestUtils.encryptedAtRest;
-import static org.sejda.core.service.TestUtils.assertPageLabelIndexesAre;
-import static org.sejda.core.service.TestUtils.assertPageLabelRangeIs;
-
-import java.awt.Rectangle;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
-import org.sejda.core.TestListenerFactory;
-import org.sejda.core.TestListenerFactory.TestListenerFailed;
-import org.sejda.core.notification.context.ThreadLocalNotificationContext;
 import org.sejda.core.service.BaseTaskTest;
 import org.sejda.impl.sambox.component.DocBuilder;
 import org.sejda.impl.sambox.component.PdfTextExtractorByArea;
@@ -66,6 +44,27 @@ import org.sejda.sambox.pdmodel.common.PDPageLabelRange;
 import org.sejda.sambox.pdmodel.common.PDPageLabels;
 import org.sejda.sambox.pdmodel.common.PDRectangle;
 import org.sejda.sambox.text.PDFTextStripperByArea;
+
+import java.awt.Rectangle;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.sejda.TestUtils.encryptedAtRest;
+import static org.sejda.core.service.TestUtils.assertPageLabelIndexesAre;
+import static org.sejda.core.service.TestUtils.assertPageLabelRangeIs;
 
 /**
  * @author Andrea Vacondio
@@ -426,10 +425,8 @@ public class MergeSamboxTaskTest extends BaseTaskTest<MergeParameters> {
         parameters.setOutlinePolicy(OutlinePolicy.RETAIN);
         parameters.addInput(new PdfMergeInput(customInput("pdf/missing_page_ref.pdf", "name.pdf")));
         testContext.pdfOutputTo(parameters);
-        TestListenerFailed failListener = TestListenerFactory.newFailedListener();
-        ThreadLocalNotificationContext.getContext().addListener(failListener);
         execute(parameters);
-        assertTrue(failListener.isFailed());
+        testContext.assertTaskFailed().assertFailedSource("name.pdf");
     }
 
     @Test
@@ -680,7 +677,8 @@ public class MergeSamboxTaskTest extends BaseTaskTest<MergeParameters> {
         execute(parameters);
 
         // TODO: friendlier error message
-        testContext.assertTaskFailed("An error occurred creating PDImageXObject from file source: corrupt.png");
+        testContext.assertTaskFailed("An error occurred creating PDImageXObject from file source: corrupt.png")
+                .assertFailedSource("corrupt.png");
     }
 
     @Test


### PR DESCRIPTION
to the NotifiableTaskMetadata so that one can listen for the TaskExecutionFailedEvent and know what file caused the failure.